### PR TITLE
Add InjectLab to Tools Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 
 - [Token Turbulenz](https://github.com/wunderwuzzi23/token-turbulenz) - A fuzzer to automate looking for possible Prompt Injections.
 - [Garak](https://github.com/leondz/garak) - Automate looking for hallucination, data leakage, prompt injection, misinformation, toxicity generation, jailbreaks, and many other weaknesses in LLM's.
+- [InjectLab](https://github.com/ahow2004/injectlab) - A MITRE-style matrix of adversarial prompt injection techniques with mitigations and real-world examples
 
 ## CTF
 


### PR DESCRIPTION
This request adds [InjectLab](https://github.com/ahow2004/injectlab) to the tools section. InjectLab is a comprehensive matrix that catalogs adversarial prompt injection techniques, offering insights into mitigation and real world examples. It also offers a python test program to automate .yaml based testing of TTPs, similar to Red Canary's Atomic Red Team. 