### PR TITLE
Add openclaw-bastion prompt injection defense tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [Token Turbulenz](https://github.com/wunderwuzzi23/token-turbulenz) - A fuzzer to automate looking for possible Prompt Injections.
 - [Garak](https://github.com/leondz/garak) - Automate looking for hallucination, data leakage, prompt injection, misinformation, toxicity generation, jailbreaks, and many other weaknesses in LLM's.
 - [InjectLab](https://github.com/ahow2004/injectlab) - A MITRE-style matrix of adversarial prompt injection techniques with mitigations and real-world examples
+- [openclaw-bastion](https://github.com/AtlasPA/openclaw-bastion) - Open-source prompt injection defense for AI agent workspaces. Detects system prompt markers, role overrides, instruction injection, Unicode homoglyphs, directional overrides, and hidden instructions in HTML comments. Part of the OpenClaw Security Suite (11 tools). Pure Python stdlib, zero dependencies.
 
 ## CTF
 


### PR DESCRIPTION
## Summary

Adds [openclaw-bastion](https://github.com/AtlasPA/openclaw-bastion) to the Tools section.

openclaw-bastion is an open-source prompt injection defense tool for AI agent workspaces. It detects:

- System prompt markers and role overrides
- Instruction injection patterns
- Unicode homoglyphs and directional overrides
- Hidden instructions in HTML comments

Pure Python stdlib with zero dependencies. Part of the [OpenClaw Security Suite](https://github.com/AtlasPA) (11 tools).

Repo: https://github.com/AtlasPA/openclaw-bastion