### PR TITLE
Add PIC Standard to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [Token Turbulenz](https://github.com/wunderwuzzi23/token-turbulenz) - A fuzzer to automate looking for possible Prompt Injections.
 - [Garak](https://github.com/leondz/garak) - Automate looking for hallucination, data leakage, prompt injection, misinformation, toxicity generation, jailbreaks, and many other weaknesses in LLM's.
 - [InjectLab](https://github.com/ahow2004/injectlab) - A MITRE-style matrix of adversarial prompt injection techniques with mitigations and real-world examples
+- [PIC Standard](https://github.com/madeinplutofabio/pic-standard) – Protocol to block unauthorized or unproven agent actions via intent + provenance checks. Mitigates prompt injection & side-effect risks. Open-source (Apache 2.0).
 
 ## CTF
 


### PR DESCRIPTION
PIC is a lightweight, local-first protocol that forces AI agents to prove every important action before it happens. Agents must declare intent, risk, provenance, and evidence; PIC verifies everything and fails closed if anything is wrong.

No more hallucinations turning into wire transfers. No more prompt injections triggering data exports.

Example: An LLM agent decides to send a $500 payment based on a user message. PIC requires the agent to prove: where did this instruction come from? Is the source trusted? Is there evidence the invoice is real? If any answer is missing or wrong, the action is blocked before it reaches the payment API.