### PR TITLE
Add prompt-shield to defense/mitigation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [Vigil LLM](https://github.com/deadbits/vigil-llm) - Python library and REST API with composable stacked scanners: vector similarity, YARA rules, transformer classifier, canary token detection, and sentiment analysis — designed for defence-in-depth in production.
 - [InjecGuard](https://github.com/safolab-wisc/injecguard) - Open-source prompt guard with published training data; achieves +30.8% over prior state-of-the-art on the NotInject benchmark, specifically addressing overdefense false positives that break legitimate use cases.
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
+- [prompt-shield](https://github.com/mthamil107/prompt-shield) - Prompt injection detection engine with 23 detectors, ensemble scoring, self-learning vault, and PII redaction.
 
 ## CTF
 


### PR DESCRIPTION
Adds prompt-shield — an open-source, self-learning prompt injection detection engine for LLM applications.

- 23 detectors (regex + DeBERTa ML classifier)
- PII detection & redaction
- Ensemble scoring, self-learning vault
- FastAPI/Flask/Django middleware, LangChain/LlamaIndex integrations

GitHub: https://github.com/mthamil107/prompt-shield
PyPI: https://pypi.org/project/prompt-shield-ai/