### PR TITLE
Add brood-box to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [Sentinel AI](https://github.com/MaxwellCalkin/sentinel-ai) - Real-time prompt injection detection across 12 languages with sub-millisecond regex-based scanning (no GPU or API calls required). Detects obfuscation techniques (base64, hex, ROT13, leetspeak), Claude Code attack vectors (HTML comment injection, authority impersonation, zero-width character smuggling), and includes an MCP safety proxy for transparent guardrails on any MCP server.
 - [AgentSeal](https://github.com/agentseal/agentseal) - Open-source scanner that runs 150 attack probes against AI agents to test for prompt injection and extraction vulnerabilities. Supports OpenAI, Anthropic, Ollama, and any HTTP endpoint. Available as npm and pip   
   package.  
+- [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 
 ## CTF
 


### PR DESCRIPTION
## Add brood-box to Tools

[brood-box](https://github.com/stacklok/brood-box) is a defense tool that contains the blast radius of prompt injection attacks on coding agents (Claude Code, Codex, OpenCode).

Rather than trying to detect or filter prompt injections — which research shows is fundamentally limited — brood-box takes an architectural containment approach: every agent session runs inside a hardware-isolated microVM with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles.

Even if an attacker successfully injects a prompt that tricks an agent into exfiltrating data or reading credentials, the hardware-isolated microVM means there are no real credentials to steal (credentials are never exposed inside the sandbox), egress is controlled (DNS-aware policies restrict what the agent can reach), and workspace changes go through a snapshot diff and review process before being flushed back to the host.

This aligns with Meta's "Agents Rule of Two" principle already referenced in the repo: brood-box ensures the agent satisfies at most two of the three risky properties (processing untrustworthy inputs, access to sensitive data, ability to change state externally) by architecturally removing access to sensitive data and controlling external state changes.

🤖 Generated with [Claude Code](https://claude.ai/code) and [Brood Box](https://github.com/stacklok/brood-box)