### PR TITLE
Add AgentShield to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [InjecGuard](https://github.com/safolab-wisc/injecguard) - Open-source prompt guard with published training data; achieves +30.8% over prior state-of-the-art on the NotInject benchmark, specifically addressing overdefense false positives that break legitimate use cases.
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
+- [AgentShield](https://github.com/hidearmoon/agentshield) - Runtime security layer that intercepts AI agent tool calls with 3-layer intent consistency detection (rules → anomaly → semantic), trust-aware data flow preventing untrusted sources from triggering sensitive tools, and two-phase call architecture that physically separates data extraction from action execution. Includes 92 security tests with attack sample corpus covering direct/indirect injection, encoding bypass, and multi-vector chains.
 
 ## CTF
 


### PR DESCRIPTION
Added [AgentShield](https://github.com/hidearmoon/agentshield) to the Tools section.

AgentShield is specifically designed to defend against prompt injection in AI agent tool-calling scenarios. Relevant to this list:

**Defense approach:**
- 3-layer intent consistency detection catches injection attempts before tool execution
- Trust-aware data flow tags external sources (emails, web pages, RAG docs) as lower trust, preventing them from triggering sensitive operations
- Two-phase call architecture physically separates data extraction (no tools available) from action execution (structured data only) — even if injection succeeds in phase 1, there are no tools to abuse

**Testing corpus:**
- 92 dedicated security tests covering direct injection, indirect injection, encoding bypass (Unicode, base64, URL encoding, HTML entities), header forgery, trust escalation, and combined multi-vector attacks
- Attack samples in JSONL format at `tests/security/samples/` — could be a useful resource for the community

GitHub: https://github.com/hidearmoon/agentshield