### PR TITLE
Add prompt-shield — cross-domain prompt injection detection (arXiv:2604.18248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [InjecGuard](https://github.com/safolab-wisc/injecguard) - Open-source prompt guard with published training data; achieves +30.8% over prior state-of-the-art on the NotInject benchmark, specifically addressing overdefense false positives that break legitimate use cases.
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
+- [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
 
 ## CTF
 


### PR DESCRIPTION
Submitting [prompt-shield](https://github.com/mthamil107/prompt-shield), an open-source prompt injection detection engine that applies cross-domain techniques from bioinformatics, forensic linguistics, and materials science.

I submitted this project previously (#20) and it was closed for not meeting the originality bar — fair assessment at the time. Since then the project has shipped three novel detection techniques with a published research paper:

**Novel techniques (addressing the "originality and substance" criterion from CONTRIBUTING.md):**

- **Smith-Waterman local sequence alignment** (from bioinformatics) — uses a semantic substitution matrix to detect paraphrased attack subsequences. On the deepset/prompt-injections benchmark: +34.5pp F1, +21.7pp recall, 0% FPR increase over baseline.
- **Stylometric discontinuity detection** (from forensic linguistics) — computes Jensen-Shannon divergence on sliding-window feature vectors to detect author-change boundaries where injected text begins.
- **Adversarial fatigue tracking** (from materials science) — models per-source threshold hardening using EWMA on near-miss scores, inspired by S-N fatigue curves, to detect low-and-slow probing campaigns.

**Research paper:** [arXiv:2604.18248](https://arxiv.org/abs/2604.18248) — *Beyond Pattern Matching: Seven Cross-Domain Techniques for Prompt Injection Detection*

**Benchmarks:** Evaluated on 6 public datasets (deepset/prompt-injections, Microsoft LLMail-Inject, JailbreakBench, TensorTrust, HackAPrompt, NotInject). Full results in the paper.

**Project:** 27 input detectors, 6 output scanners, 10 languages, Apache-2.0 licensed, 555 prompts/sec with no external API calls. Drop-in integrations for FastAPI, Flask, Django, LangChain, LlamaIndex, CrewAI, n8n, and OpenAI/Anthropic client wrappers.

Happy to adjust the listing format to match your conventions.