### PR TITLE
Add Bulwark to defensive frameworks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [InjecGuard](https://github.com/safolab-wisc/injecguard) - Open-source prompt guard with published training data; achieves +30.8% over prior state-of-the-art on the NotInject benchmark, specifically addressing overdefense false positives that break legitimate use cases.
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
+- [Bulwark](https://github.com/anilatambharii/bulwark) - Open-source defensive framework: pattern-based + ML-augmented prompt injection detection, plus RBAC, audit, and human gate layers. Vendor-neutral (Anthropic / OpenAI / MCP / LangChain). [[demo](https://huggingface.co/spaces/AmbhariiLabs/bulwark-demo)]
+
 
 ## CTF
 


### PR DESCRIPTION
Added Bulwark to the list of open-source defensive frameworks for prompt injection detection.