### PR TITLE
Add Bulwark to defensive frameworks — v0.2.0 re-submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [InjecGuard](https://github.com/safolab-wisc/injecguard) - Open-source prompt guard with published training data; achieves +30.8% over prior state-of-the-art on the NotInject benchmark, specifically addressing overdefense false positives that break legitimate use cases.
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
+- [Bulwark](https://github.com/anilatambharii/bulwark) - Open-source Python framework for production AI agents: five-layer defense pipeline (input sanitization, 22-pattern injection detection with optional DeBERTa-v3 transformer classifier, RBAC, human confirmation gates, encrypted audit trail). Pattern-only default needs no ML dependencies; the transformer layer is an opt-in extra. Vendor-neutral; integrates with MCP, Anthropic, OpenAI, and LangChain. Apache 2.0, v0.2.0, >90% test coverage.
 
 ## CTF
 


### PR DESCRIPTION
## What this adds

Adds [Bulwark](https://github.com/anilatambharii/bulwark) to the **Tools** section — an open-source Python framework that wraps AI agent tool calls in a five-layer defense pipeline.

## Addressing the previous review (#42)

The prior PR was closed with three concerns. Each is resolved in v0.2.0:

### 1. "ML detection not actually implemented"

The previous README and architecture diagram claimed *"BERT + regex"* but shipped no model weights. This was misleading and is now fixed:

- **Default mode (pattern-only):** 22 curated regex signatures covering role-marker overrides, jailbreak directives, special token injection (`<|im_start|>`, `[INST]`…), prompt-leak attempts, virtualization jailbreaks, memory poisoning, credential phishing, markdown-exfiltration links, and more. Zero external dependencies, deterministic, < 5 ms.
- **Optional ML mode** (`pip install bulwark-agent-security[ml]`): loads [`protectai/deberta-v3-base-prompt-injection-v2`](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2) — a DeBERTa-v3 model specifically fine-tuned for prompt injection detection. Label handling is implemented and tested for that model's INJECTION/LEGIT output labels. Documentation now clearly states: *pattern-based is the default; the transformer is an opt-in extra.*

### 2. "CI is failing"

- Redundant `--cov` flags removed from `pytest addopts`; coverage is now explicitly enforced in the CI command (`--cov-fail-under=90`).
- `pytest-timeout` added; `--timeout=60` prevents hanging async tests from stalling the matrix.
- Codecov upload marked `continue-on-error` so a missing token doesn't block test jobs.
- All 166 tests pass on Python 3.10/3.11/3.12 × Ubuntu/macOS/Windows; coverage 91.17%.

### 3. "Little activity beyond the initial push"

Since the original submission (v0.1.0, May 2):
- v0.2.0 tagged and pushed (June 3)
- 7 new attack patterns added (catalog: 15 → 22)
- All three reviewer concerns addressed in code, not just docs
- CHANGELOG, architecture docs, and pyproject.toml URLs updated

## Project facts

| | |
|---|---|
| License | Apache 2.0 |
| Version | 0.2.0 |
| Python | 3.10 / 3.11 / 3.12 |
| Test coverage | 91.17% (166 tests) |
| CI | 3 OS × 3 Python versions |
| Dependencies (core) | pydantic, cryptography, httpx, python-jose |
| Integrations | MCP, Anthropic SDK, OpenAI SDK, LangChain |