### PR TITLE
Add Regulus to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [Regulus](https://github.com/neul-labs/regulus) – Open-source EU & UK compliance plane for Google ADK. Detects prompt-injection and tool-poisoning attempts at the tool-call boundary via `BeforeToolCallback` and `AfterToolCallback` ADK plugin hooks, blocks unauthorized tool invocations, redacts PII, and emits a hash-chained audit envelope mapped to OWASP Agentic Top 10. Java 21, MIT.
 
 ## CTF
 


### PR DESCRIPTION
Adds [Regulus](https://github.com/neul-labs/regulus) — the EU & UK compliance plane for Google ADK — to the **Tools** section.

Regulus is a Java 21, MIT-licensed runtime ADK `BasePlugin` suite. It detects prompt-injection and tool-poisoning attempts at the tool-call boundary via `BeforeToolCallback` and `AfterToolCallback` ADK plugin hooks, blocks unauthorized tool invocations, redacts PII, and emits a hash-chained audit envelope mapped to the OWASP Agentic Top 10.

Fits as a defense-side runtime that complements the existing scanner/red-team tools in this section. The contributing guide requires substantive, maintained, MIT/FOSS-licensed projects with real security engineering — Regulus meets all three.