### PR TITLE
Add bulwark-mcp to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [bulwark-mcp](https://github.com/churik5/bulwark-mcp) - Local stdio proxy between an MCP client and server that detects and blocks indirect prompt injection in tool results before they reach the agent. Layered defense (regex, optional local LLM, YAML policy), fully local, no telemetry. AGPL-3.0, Python.
 
 ## CTF
 


### PR DESCRIPTION
Adds bulwark-mcp — a local stdio proxy that sits between an MCP client and server and detects/blocks indirect prompt injection in tool results before the agent reads them. MCP-specific (understands JSON-RPC, tools/call vs tools/list), fully local, no telemetry. Fits the Tools section.

AGPL-3.0, Python. Repo: https://github.com/churik5/bulwark-mcp