### PR TITLE
Add fak (Fused Agent Kernel) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [fak (Fused Agent Kernel)](https://github.com/anthony-chaudhary/fak) - Agent kernel (single Go binary) that adjudicates every tool call on the same call path before it runs: a default-deny capability gate the model can't talk past, plus a quarantine that holds suspicious tool results out of the model's context entirely — so an injected instruction reaches neither the lever nor the context. Two independent gates, not one classifier. Apache-2.0.
 
 ## CTF
 


### PR DESCRIPTION
Adds [fak](https://github.com/anthony-chaudhary/fak) to the Tools section.

**fak** is an agent kernel — a single Go binary that puts the permission check on the *same call path* as the tool call (default-deny, one address space), and quarantines suspicious tool results out of the model's context entirely. Against prompt injection that means two independent gates rather than one classifier: the dangerous lever is never wired up (so refusal doesn't depend on *catching* the attack), and the injected bytes never reach the model. Apache-2.0, zero external deps.

Sits naturally beside PIC Standard (intent/provenance gating of agent actions) and brood-box (containing prompt-injection damage). Entry follows the section's existing `- [Name](url) - Description.` format.