### PR TITLE
Add HOL Guard to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [HOL Guard](https://github.com/hashgraph-online/hol-guard) - Local-first security harness that intercepts tool calls in AI coding agents before execution. Detects prompt injection in skills and MCP servers, blocks data exfiltration, and quarantines untrusted artifacts. Supports Codex, Claude Code, Cursor, Gemini, Copilot CLI, Hermes, and OpenCode.
 
 ## CTF
 


### PR DESCRIPTION
HOL Guard is a local-first security harness that intercepts supported tool calls in AI coding agents before execution. It evaluates prompt-injection, secret-exposure, unsafe-command, package, and MCP risks, with support varying by agent and event type.

Docs: https://hol.org/guard
Repo: https://github.com/hashgraph-online/hol-guard

**Disclosure:** I am President of HOL / Hashgraph Online and am materially affiliated with HOL Guard.