### PR TITLE
Add Sunglasses (runtime trust scanner for AI agents) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [Sunglasses](https://github.com/sunglasses-dev/sunglasses) - Open-source runtime trust scanner for AI agents. 1,089 detection patterns across 65 attack categories (prompt injection, tool poisoning, MCP attacks, skill compromise) plus a mechanism layer that catches attack shapes instead of only known strings. Published benchmark: 97.4% recall, 78.7% precision. Available as a pip package, GitHub Action, and free web scanner. MIT licensed.
 
 ## CTF
 


### PR DESCRIPTION
Hi, I am the author of Sunglasses, submitting per your contribution guidelines. Checking myself against your criteria honestly:

Free and open source: yes, MIT license, core scanner fully local via pip install sunglasses. The web scanner at sunglasses.dev/scan is free with no paid tier behind it.

Original and substantive: it is not an LLM wrapper. Detection is a hand-curated corpus of 1,089 regex patterns across 65 attack categories (prompt injection, tool poisoning, MCP attacks, skill compromise), plus a mechanism layer that targets attack shapes rather than known strings. No API keys, no model calls, runs offline.

Real engineering effort: built and shipped continuously since February 2026, full pytest suite runs in CI on every PR, and we publish a precision/recall benchmark (97.4% recall, 78.7% precision) at sunglasses.dev/benchmark rather than making unmeasured claims.

Maintained and functional: latest release v0.3.1 shipped July 12, documented at sunglasses.dev with pip, GitHub Action, and web scan usage.

Happy to adjust wording or placement if anything does not fit.