### PR TITLE
Add prompt-protection to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [prompt-protection](https://github.com/mughalhere/prompt-protection) - Zero-dependency LLM firewall for Node.js and browsers: 117 rules detecting prompt injection, jailbreaks, and data exfiltration on input, plus system-prompt-leak, credential, and PII scanning on output. Runs in-process, no API calls. MIT.
 
 ## CTF
 


### PR DESCRIPTION
Adds [prompt-protection](https://github.com/mughalhere/prompt-protection) to the Tools section.

MIT-licensed, zero-dependency library for Node.js and browsers. On input it detects prompt injection, jailbreaks, and data exfiltration (117 rules across seven categories, with Unicode/homoglyph/base64 normalisation to defeat obfuscation); on output it scans for system-prompt leaks, exposed credentials, and PII. Everything runs in-process with no API calls, so it fits as a fast deterministic first layer.

Entry follows the existing Tools list format.
