### PR TITLE
Add sentinel-scan-cli to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The severity of a prompt injection attack can vary, influenced by factors like t
 - [tldrsec/prompt-injection-defenses](https://github.com/tldrsec/prompt-injection-defenses) - Actively maintained catalog of every practical defense in production — LLM Guard, Rebuff, architectural controls — the fastest way to survey the defense landscape.
 - [brood-box](https://github.com/stacklok/brood-box) - Hardware-isolated microVM sandbox for running coding agents (Claude Code, Codex, OpenCode) with workspace snapshot isolation, DNS-aware egress control, and MCP authorization profiles to contain damage from prompt injection attacks.
 - [prompt-shield](https://github.com/mthamil107/prompt-shield) - Self-learning prompt injection detection engine with novel cross-domain techniques: Smith-Waterman sequence alignment (bioinformatics), stylometric discontinuity detection (forensic linguistics), and adversarial fatigue tracking (materials science). 27 detectors, 6 output scanners, 10 languages, benchmarked on 6 public datasets. Research paper: [arXiv:2604.18248](https://arxiv.org/abs/2604.18248). Apache-2.0.
+- [sentinel-scan-cli](https://github.com/Ventrova/sentinel-scan-cli) - Free MIT-licensed CLI offensive testing tool: fires 15 prompt-injection and jailbreak technique families (DAN-style roleplay, base64 smuggling, indirect injection via simulated tool output, format-string exfiltration, and more) at any OpenAI-compatible chat completions endpoint. Scores each response for literal-secret-leak and refusal-heuristic. Ships with a zero-network `--demo` mode.
 
 ## CTF
 


### PR DESCRIPTION
Adds a free, MIT-licensed offensive testing CLI (https://github.com/Ventrova/sentinel-scan-cli) that fires 15 prompt-injection/jailbreak technique families at any OpenAI-compatible endpoint, similar in spirit to the other offensive tools already listed (Augustus, Garak). Includes a zero-network --demo mode. Disclosure: I'm Ventrova (ventrova.dev), the maintainer, submitting our own project per this list's normal contribution pattern.